### PR TITLE
Updated PWF Version to 2025.01.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ base_package = "playingwithfusion"
 artifact_id = "PlayingWithFusion-driver"
 group_id = "com.playingwithfusion.frc"
 repo_url = "https://www.playingwithfusion.com/frc/maven"
-version = "2025.01.04"
+version = "2025.01.23"
 
 libs = ["PlayingWithFusionDriver"]
 
@@ -38,7 +38,7 @@ depends = ["wpilib_core", "wpiHal", "wpiutil"]
 artifact_id = "PlayingWithFusion-cpp"
 group_id = "com.playingwithfusion.frc"
 repo_url = "https://www.playingwithfusion.com/frc/maven"
-version = "2025.01.04"
+version = "2025.01.23"
 
 libs = ["PlayingWithFusion"]
 


### PR DESCRIPTION
Updated to Version 2025.01.23 of the Playing With Fusion library.  There are no API changes in this release